### PR TITLE
fix min update break chapter issue

### DIFF
--- a/patches/fix-min-update-chapter.diff
+++ b/patches/fix-min-update-chapter.diff
@@ -1,0 +1,124 @@
+diff -urwN -U5 tmp/dec/smali_classes2/com/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher.smali tmp/mod/smali_classes2/com/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher.smali
+--- tmp/dec/smali_classes2/com/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher.smali	2024-02-24 06:26:42.000000000 +0900
++++ tmp/mod/smali_classes2/com/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher.smali	2024-02-27 10:50:47.718780084 +0900
+@@ -233,10 +233,18 @@
+     iget v0, p0, Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;->mChapter:I
+ 
+     return v0
+ .end method
+ 
++.method public setChapter(I)V
++    .locals 1
++
++    iput p1, p0, Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;->mChapter:I
++
++    return-void
++.end method
++
+ .method public getChapterTitle()Ljava/lang/String;
+     .locals 1
+ 
+     .line 129
+     iget-object v0, p0, Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;->mChapterElement:Lorg/jsoup/nodes/Element;
+diff -urwN -U5 tmp/dec/smali_classes2/com/tscsoft/naroureader/beans/ListBean.smali tmp/mod/smali_classes2/com/tscsoft/naroureader/beans/ListBean.smali
+--- tmp/dec/smali_classes2/com/tscsoft/naroureader/beans/ListBean.smali	2024-02-24 06:29:07.000000000 +0900
++++ tmp/mod/smali_classes2/com/tscsoft/naroureader/beans/ListBean.smali	2024-02-27 10:40:46.428967778 +0900
+@@ -91,10 +91,12 @@
+ 
+ .field private prevAllNo:I
+ 
+ .field private workMode:Lcom/tscsoft/naroureader/services/ServiceItem$WorkMode;
+ 
++.field private updateStartNo:I
++
+ 
+ # direct methods
+ .method public constructor <init>()V
+     .locals 2
+ 
+@@ -2712,5 +2714,21 @@
+ 
+     iput-object p1, p0, Lcom/tscsoft/naroureader/beans/ListBean;->workMode:Lcom/tscsoft/naroureader/services/ServiceItem$WorkMode;
+ 
+     return-void
+ .end method
++
++.method public getUpdateStartNo()I
++    .locals 1
++
++    iget v0, p0, Lcom/tscsoft/naroureader/beans/ListBean;->updateStartNo:I
++
++    return v0
++.end method
++
++.method public setUpdateStartNo(I)V
++    .locals 0
++
++    iput p1, p0, Lcom/tscsoft/naroureader/beans/ListBean;->updateStartNo:I
++
++    return-void
++.end method
+diff -urwN -U5 tmp/dec/smali_classes2/com/tscsoft/naroureader/utils/UpdateManager.smali tmp/mod/smali_classes2/com/tscsoft/naroureader/utils/UpdateManager.smali
+--- tmp/dec/smali_classes2/com/tscsoft/naroureader/utils/UpdateManager.smali	2024-02-24 06:29:07.000000000 +0900
++++ tmp/mod/smali_classes2/com/tscsoft/naroureader/utils/UpdateManager.smali	2024-02-27 11:27:01.478090955 +0900
+@@ -5009,10 +5012,12 @@
+     :try_start_0
+     invoke-virtual {v0}, Lcom/tscsoft/naroureader/NovelHtmlObject;->episodeFetcher()Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;
+ 
+     move-result-object v1
+ 
++    invoke-direct {p0, p1, v1}, Lcom/tscsoft/naroureader/utils/UpdateManager;->modEpisodeFetcherChapter(Lcom/tscsoft/naroureader/beans/ListBean;Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;)V
++
+     .line 662
+     new-instance v2, Ljava/util/ArrayList;
+ 
+     invoke-direct {p0, p1, v1}, Lcom/tscsoft/naroureader/utils/UpdateManager;->updateEpisode(Lcom/tscsoft/naroureader/beans/ListBean;Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;)Ljava/util/List;
+ 
+@@ -5751,5 +5756,47 @@
+ 
+     move-result-object p1
+ 
+     return-object p1
+ .end method
++
++.method private modEpisodeFetcherChapter(Lcom/tscsoft/naroureader/beans/ListBean;Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;)V
++    .locals 3
++
++    .line 15
++    invoke-virtual {p1}, Lcom/tscsoft/naroureader/beans/ListBean;->getUpdateStartNo()I
++
++    move-result v0
++
++    const/4 v1, 0x1
++
++    sub-int/2addr v0, v1
++
++    if-ge v0, v1, :cond_0
++
++    return-void
++
++    .line 17
++    :cond_0
++    new-instance v1, Lcom/tscsoft/naroureader/beans/NovelBean;
++
++    invoke-direct {v1}, Lcom/tscsoft/naroureader/beans/NovelBean;-><init>()V
++
++    .line 18
++    invoke-virtual {p1}, Lcom/tscsoft/naroureader/beans/ListBean;->getNcode()Ljava/lang/String;
++
++    move-result-object p1
++
++    iget-object v2, p0, Lcom/tscsoft/naroureader/utils/UpdateManager;->mEpisodeAccessor:Lcom/tscsoft/naroureader/beans/NovelBean$Accessor;
++
++    invoke-direct {p0, p1, v0, v1, v2}, Lcom/tscsoft/naroureader/utils/UpdateManager;->loadEpisode(Ljava/lang/String;ILcom/tscsoft/naroureader/beans/NovelBean;Lcom/tscsoft/naroureader/beans/NovelBean$Accessor;)Z
++
++    .line 19
++    invoke-virtual {v1}, Lcom/tscsoft/naroureader/beans/NovelBean;->getChapter()I
++
++    move-result p1
++
++    .line 20
++    invoke-virtual {p2, p1}, Lcom/tscsoft/naroureader/NovelHtmlObject$EpisodeFetcher;->setChapter(I)V
++
++    return-void
++.end method

--- a/patches/smali/com/tscsoft/naroureader/utils/Modding$1.smali
+++ b/patches/smali/com/tscsoft/naroureader/utils/Modding$1.smali
@@ -22,7 +22,7 @@
 .method static constructor <clinit>()V
     .locals 3
 
-    .line 72
+    .line 89
     invoke-static {}, Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;->values()[Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;
 
     move-result-object v0

--- a/patches/smali/com/tscsoft/naroureader/utils/Modding.smali
+++ b/patches/smali/com/tscsoft/naroureader/utils/Modding.smali
@@ -3,11 +3,30 @@
 .source "Modding.java"
 
 
+# static fields
+.field public static final PATTERN_PAGE_LINK:Ljava/util/regex/Pattern;
+
+
 # direct methods
+.method static constructor <clinit>()V
+    .locals 1
+
+    const-string v0, "/n\\d{4}[a-z]+/(\\d+?)/"
+
+    .line 23
+    invoke-static {v0}, Ljava/util/regex/Pattern;->compile(Ljava/lang/String;)Ljava/util/regex/Pattern;
+
+    move-result-object v0
+
+    sput-object v0, Lcom/tscsoft/naroureader/utils/Modding;->PATTERN_PAGE_LINK:Ljava/util/regex/Pattern;
+
+    return-void
+.end method
+
 .method public constructor <init>()V
     .locals 0
 
-    .line 20
+    .line 22
     invoke-direct {p0}, Ljava/lang/Object;-><init>()V
 
     return-void
@@ -21,7 +40,7 @@
         }
     .end annotation
 
-    .line 84
+    .line 101
     invoke-static {p0}, Landroid/text/TextUtils;->isEmpty(Ljava/lang/CharSequence;)Z
 
     move-result v0
@@ -30,7 +49,7 @@
 
     return-object p0
 
-    .line 85
+    .line 102
     :cond_0
     invoke-static {p0}, Lorg/jsoup/Jsoup;->parse(Ljava/lang/String;)Lorg/jsoup/nodes/Document;
 
@@ -38,7 +57,7 @@
 
     const-string v1, "a.novelview_pager-last[href]"
 
-    .line 86
+    .line 103
     invoke-virtual {v0, v1}, Lorg/jsoup/nodes/Document;->selectFirst(Ljava/lang/String;)Lorg/jsoup/nodes/Element;
 
     move-result-object v0
@@ -47,7 +66,7 @@
 
     return-object p0
 
-    .line 88
+    .line 105
     :cond_1
     new-instance p0, Ljava/net/URL;
 
@@ -63,7 +82,7 @@
 
     invoke-direct {p0, v1, v0}, Ljava/net/URL;-><init>(Ljava/net/URL;Ljava/lang/String;)V
 
-    .line 89
+    .line 106
     new-instance v0, Ljava/lang/StringBuilder;
 
     const-string v1, "Fetch: "
@@ -82,7 +101,7 @@
 
     invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 90
+    .line 107
     invoke-virtual {p0}, Ljava/net/URL;->toExternalForm()Ljava/lang/String;
 
     move-result-object p0
@@ -92,6 +111,67 @@
     move-result-object p0
 
     return-object p0
+.end method
+
+.method private static getUpdateStartNo(Lorg/jsoup/nodes/Document;)I
+    .locals 2
+
+    const-string v0, ".index_box .subtitle a[href]"
+
+    .line 26
+    invoke-virtual {p0, v0}, Lorg/jsoup/nodes/Document;->selectFirst(Ljava/lang/String;)Lorg/jsoup/nodes/Element;
+
+    move-result-object p0
+
+    const/4 v0, 0x0
+
+    if-nez p0, :cond_0
+
+    return v0
+
+    :cond_0
+    const-string v1, "href"
+
+    .line 28
+    invoke-virtual {p0, v1}, Lorg/jsoup/nodes/Element;->attr(Ljava/lang/String;)Ljava/lang/String;
+
+    move-result-object p0
+
+    sget-object v1, Lcom/tscsoft/naroureader/utils/Modding;->PATTERN_PAGE_LINK:Ljava/util/regex/Pattern;
+
+    .line 29
+    invoke-virtual {v1, p0}, Ljava/util/regex/Pattern;->matcher(Ljava/lang/CharSequence;)Ljava/util/regex/Matcher;
+
+    move-result-object p0
+
+    .line 30
+    invoke-virtual {p0}, Ljava/util/regex/Matcher;->find()Z
+
+    move-result v1
+
+    if-nez v1, :cond_1
+
+    return v0
+
+    :cond_1
+    const/4 v1, 0x1
+
+    .line 31
+    invoke-virtual {p0, v1}, Ljava/util/regex/Matcher;->group(I)Ljava/lang/String;
+
+    move-result-object p0
+
+    if-nez p0, :cond_2
+
+    return v0
+
+    .line 33
+    :cond_2
+    invoke-static {p0}, Ljava/lang/Integer;->parseInt(Ljava/lang/String;)I
+
+    move-result p0
+
+    return p0
 .end method
 
 .method public static patchNovelHtml(Ljava/lang/String;Lcom/tscsoft/naroureader/http/HttpGet;Lcom/tscsoft/naroureader/beans/ListBean;)Ljava/lang/String;
@@ -107,10 +187,10 @@
 
     const-string v1, "NarouModding"
 
-    .line 22
+    .line 36
     invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 23
+    .line 37
     new-instance v0, Ljava/lang/StringBuilder;
 
     const-string v2, "listBean: "
@@ -127,7 +207,7 @@
 
     invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 24
+    .line 38
     new-instance v0, Ljava/lang/StringBuilder;
 
     const-string v2, "listBean.url: "
@@ -148,7 +228,7 @@
 
     invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 25
+    .line 39
     new-instance v0, Ljava/lang/StringBuilder;
 
     const-string v2, "listBean.workMode: "
@@ -169,7 +249,7 @@
 
     invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 26
+    .line 40
     new-instance v0, Ljava/lang/StringBuilder;
 
     const-string v2, "listBean.prevAllNo: "
@@ -190,7 +270,7 @@
 
     invoke-static {v1, v0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 27
+    .line 41
     invoke-virtual {p2}, Lcom/tscsoft/naroureader/beans/ListBean;->isShort()Z
 
     move-result v0
@@ -207,7 +287,7 @@
 
     goto/16 :goto_2
 
-    .line 28
+    .line 42
     :cond_0
     invoke-static {p0}, Lorg/jsoup/Jsoup;->parse(Ljava/lang/String;)Lorg/jsoup/nodes/Document;
 
@@ -215,7 +295,7 @@
 
     const-string v3, ".index_box"
 
-    .line 29
+    .line 43
     invoke-virtual {v0, v3}, Lorg/jsoup/nodes/Document;->selectFirst(Ljava/lang/String;)Lorg/jsoup/nodes/Element;
 
     move-result-object v4
@@ -224,7 +304,7 @@
 
     return-object p0
 
-    .line 32
+    .line 46
     :cond_1
     invoke-virtual {p2}, Lcom/tscsoft/naroureader/beans/ListBean;->getPrevAllNo()I
 
@@ -244,7 +324,7 @@
 
     add-int/2addr p0, v5
 
-    .line 33
+    .line 47
     invoke-static {}, Lcom/tscsoft/naroureader/settings/GS;->gs()Lcom/tscsoft/naroureader/settings/GS;
 
     move-result-object v2
@@ -253,7 +333,7 @@
 
     move-result v2
 
-    .line 34
+    .line 48
     new-instance v6, Ljava/lang/StringBuilder;
 
     const-string v7, "pageNo: "
@@ -270,7 +350,7 @@
 
     invoke-static {v1, v6}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 35
+    .line 49
     new-instance v6, Ljava/lang/StringBuilder;
 
     const-string v7, "needMinIndexUpdate: "
@@ -289,31 +369,31 @@
 
     if-eqz v2, :cond_2
 
-    .line 36
+    .line 50
     invoke-virtual {p2}, Lcom/tscsoft/naroureader/beans/ListBean;->getWorkMode()Lcom/tscsoft/naroureader/services/ServiceItem$WorkMode;
 
-    move-result-object p2
+    move-result-object v2
 
-    sget-object v2, Lcom/tscsoft/naroureader/services/ServiceItem$WorkMode;->FullCheck:Lcom/tscsoft/naroureader/services/ServiceItem$WorkMode;
+    sget-object v6, Lcom/tscsoft/naroureader/services/ServiceItem$WorkMode;->FullCheck:Lcom/tscsoft/naroureader/services/ServiceItem$WorkMode;
 
-    if-ne p2, v2, :cond_2
+    if-ne v2, v6, :cond_2
 
     if-le p0, v5, :cond_2
 
-    .line 37
-    new-instance p2, Ljava/net/URL;
+    .line 51
+    new-instance v0, Ljava/net/URL;
 
     invoke-virtual {p1}, Lcom/tscsoft/naroureader/http/HttpGet;->getActualUrl()Ljava/net/URL;
 
-    move-result-object v0
+    move-result-object v2
 
-    new-instance v2, Ljava/lang/StringBuilder;
+    new-instance v5, Ljava/lang/StringBuilder;
 
-    const-string v5, "?p="
+    const-string v6, "?p="
 
-    invoke-direct {v2, v5}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+    invoke-direct {v5, v6}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
 
-    invoke-virtual {v2, p0}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
+    invoke-virtual {v5, p0}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
 
     move-result-object p0
 
@@ -321,16 +401,16 @@
 
     move-result-object p0
 
-    invoke-direct {p2, v0, p0}, Ljava/net/URL;-><init>(Ljava/net/URL;Ljava/lang/String;)V
+    invoke-direct {v0, v2, p0}, Ljava/net/URL;-><init>(Ljava/net/URL;Ljava/lang/String;)V
 
-    .line 38
+    .line 52
     new-instance p0, Ljava/lang/StringBuilder;
 
-    const-string v0, "Load start from: "
+    const-string v2, "Load start from: "
 
-    invoke-direct {p0, v0}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+    invoke-direct {p0, v2}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
 
-    invoke-virtual {p0, p2}, Ljava/lang/StringBuilder;->append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
+    invoke-virtual {p0, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
 
     move-result-object p0
 
@@ -340,8 +420,8 @@
 
     invoke-static {v1, p0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 39
-    invoke-virtual {p2}, Ljava/net/URL;->toExternalForm()Ljava/lang/String;
+    .line 53
+    invoke-virtual {v0}, Ljava/net/URL;->toExternalForm()Ljava/lang/String;
 
     move-result-object p0
 
@@ -349,20 +429,45 @@
 
     move-result-object p0
 
-    .line 40
+    .line 54
     invoke-static {p0}, Lorg/jsoup/Jsoup;->parse(Ljava/lang/String;)Lorg/jsoup/nodes/Document;
 
     move-result-object v0
 
+    .line 55
+    invoke-static {v0}, Lcom/tscsoft/naroureader/utils/Modding;->getUpdateStartNo(Lorg/jsoup/nodes/Document;)I
+
+    move-result p0
+
+    .line 56
+    invoke-virtual {p2, p0}, Lcom/tscsoft/naroureader/beans/ListBean;->setUpdateStartNo(I)V
+
+    .line 57
+    new-instance p2, Ljava/lang/StringBuilder;
+
+    const-string v2, "updateStartNo: "
+
+    invoke-direct {p2, v2}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {p2, p0}, Ljava/lang/StringBuilder;->append(I)Ljava/lang/StringBuilder;
+
+    move-result-object p0
+
+    invoke-virtual {p0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object p0
+
+    invoke-static {v1, p0}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
+
     :cond_2
     const-string p0, "a.novelview_pager-next[href]"
 
-    .line 43
+    .line 60
     invoke-virtual {v0, p0}, Lorg/jsoup/nodes/Document;->selectFirst(Ljava/lang/String;)Lorg/jsoup/nodes/Element;
 
     move-result-object p2
 
-    .line 44
+    .line 61
     invoke-virtual {p1}, Lcom/tscsoft/naroureader/http/HttpGet;->getActualUrl()Ljava/net/URL;
 
     move-result-object v2
@@ -370,7 +475,7 @@
     :goto_0
     if-eqz p2, :cond_5
 
-    .line 47
+    .line 64
     new-instance v5, Ljava/net/URL;
 
     const-string v6, "href"
@@ -381,7 +486,7 @@
 
     invoke-direct {v5, v2, p2}, Ljava/net/URL;-><init>(Ljava/net/URL;Ljava/lang/String;)V
 
-    .line 48
+    .line 65
     new-instance p2, Ljava/lang/StringBuilder;
 
     const-string v2, "Fetch: "
@@ -398,7 +503,7 @@
 
     invoke-static {v1, p2}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 49
+    .line 66
     new-instance p2, Ljava/lang/StringBuilder;
 
     const-string v2, "Reset: "
@@ -415,7 +520,7 @@
 
     invoke-static {v1, p2}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 52
+    .line 69
     :try_start_0
     invoke-virtual {v5}, Ljava/net/URL;->toExternalForm()Ljava/lang/String;
 
@@ -429,10 +534,10 @@
 
     const-string v2, "Get HTML"
 
-    .line 57
+    .line 74
     invoke-static {v1, v2}, Landroid/util/Log;->d(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 58
+    .line 75
     invoke-virtual {p1}, Lcom/tscsoft/naroureader/http/HttpGet;->isSuccessful()Z
 
     move-result v2
@@ -447,13 +552,13 @@
 
     goto :goto_1
 
-    .line 60
+    .line 77
     :cond_3
     invoke-static {p2}, Lorg/jsoup/Jsoup;->parse(Ljava/lang/String;)Lorg/jsoup/nodes/Document;
 
     move-result-object p2
 
-    .line 61
+    .line 78
     invoke-virtual {p2, v3}, Lorg/jsoup/nodes/Document;->selectFirst(Ljava/lang/String;)Lorg/jsoup/nodes/Element;
 
     move-result-object v2
@@ -462,7 +567,7 @@
 
     goto :goto_1
 
-    .line 64
+    .line 81
     :cond_4
     invoke-virtual {v2}, Lorg/jsoup/nodes/Element;->html()Ljava/lang/String;
 
@@ -470,7 +575,7 @@
 
     invoke-virtual {v4, v2}, Lorg/jsoup/nodes/Element;->append(Ljava/lang/String;)Lorg/jsoup/nodes/Element;
 
-    .line 65
+    .line 82
     invoke-virtual {p2, p0}, Lorg/jsoup/nodes/Document;->selectFirst(Ljava/lang/String;)Lorg/jsoup/nodes/Element;
 
     move-result-object p2
@@ -482,17 +587,17 @@
     :catch_0
     move-exception p0
 
-    .line 54
+    .line 71
     invoke-virtual {p0}, Ljava/lang/Exception;->toString()Ljava/lang/String;
 
     move-result-object p1
 
     invoke-static {v1, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;)I
 
-    .line 55
+    .line 72
     throw p0
 
-    .line 67
+    .line 84
     :cond_5
     :goto_1
     invoke-virtual {v0}, Lorg/jsoup/nodes/Document;->outerHtml()Ljava/lang/String;
@@ -507,12 +612,12 @@
 .method public static switchViewerMode(Lcom/tscsoft/naroureader/presenters/ViewerActivityPresenter;)V
     .locals 3
 
-    .line 71
+    .line 88
     invoke-static {}, Lcom/tscsoft/naroureader/settings/GS;->gs()Lcom/tscsoft/naroureader/settings/GS;
 
     move-result-object v0
 
-    .line 72
+    .line 89
     sget-object v1, Lcom/tscsoft/naroureader/utils/Modding$1;->$SwitchMap$com$tscsoft$naroureader$settings$ViewerSetting$ViewMode:[I
 
     invoke-virtual {v0}, Lcom/tscsoft/naroureader/settings/GS;->getViewerMode()Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;
@@ -535,7 +640,7 @@
 
     goto :goto_0
 
-    .line 77
+    .line 94
     :cond_0
     sget-object v1, Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;->HorizontalScroll:Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;
 
@@ -543,13 +648,13 @@
 
     goto :goto_0
 
-    .line 74
+    .line 91
     :cond_1
     sget-object v1, Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;->VerticalPaging:Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;
 
     invoke-virtual {v0, v1}, Lcom/tscsoft/naroureader/settings/GS;->setViewerMode(Lcom/tscsoft/naroureader/settings/ViewerSetting$ViewMode;)V
 
-    .line 80
+    .line 97
     :goto_0
     invoke-virtual {p0}, Lcom/tscsoft/naroureader/presenters/ViewerActivityPresenter;->onViewerPreferenceReload()V
 

--- a/patches/version.diff
+++ b/patches/version.diff
@@ -7,7 +7,7 @@ diff -urN tmp/dec/apktool.yml tmp/mod/apktool.yml
 -  versionCode: 180
 +  versionCode: 181
 -  versionName: 1.35.6
-+  versionName: 1.35.6+0.2.1
++  versionName: 1.35.6+0.2.2
  resourcesAreCompressed: false
  sharedLibrary: false
  sparseResources: false

--- a/run.sh
+++ b/run.sh
@@ -17,6 +17,7 @@ patch -u -p0 < patches/fix-update-100.diff
 patch -u -p0 < patches/min-index-update.diff
 patch -u -p0 < patches/fix-last-page-evaluation.diff
 # patch -u -p0 < patches/switch-page-view.diff
+patch -u -p0 < patches/fix-min-update-chapter.diff
 patch -u -p0 < patches/version.diff
 
 # change package name to com.tscsoft.naroureader_mod_mod_mod


### PR DESCRIPTION
Close #1 

## Overview
低負荷更新で目次の章が破損する

## Causes
- `EpisodeFecher.moveNext` で目次ページhtmlから章と話を読み込んでいる
- 章は「何番目の章であるか」の整数で管理される (`EpisodeFecher.mChapter`)
- 低負荷更新で途中から読み込むと章の順番が正常に読み取れない

## Solutions
- 前回の目次キャッシュ情報は `UpdateManager` の `loadEpisode` メソッド(private) で `NovelBean` オブジェクト をアップデートすることで確認できる
- 章番号のみが `NovelBean.getChapter()`  メソッドで入手できる
- 低負荷更新時に今回更新範囲の１つ前の話の章番号を読込み、 `EpisodeFecher` の `mChapter`フィールドを更新する

## ToDo
- `Modding.patchNovelHtml` (目次ページhtml連結用メソッド) で、低負荷更新時に読込み開始話番号を `ListBean` オブジェクトに記録する
    - `private int ListBean.updateStartNo` フィールドとsetter/getterを作成
- `UpdateManager` クラスで `EpisodeFetcher` オブジェクト作成後に上記`updateStartNo`を利用して`updateStartNo - 1` 話の章番号をロード、 `EpisodeFecher.mChapter` を更新
    - `EpisodeFecher.mChapter` にはsetterがないため追加
    - `UpdateManger` のprivate要素を複数参照するため、`Modding`クラスのstaticメソッドではなく、`UpdateManager`のメソッド`modEpisodeFetcherChapter`として追加する